### PR TITLE
feat: add progress tracking over model output folder

### DIFF
--- a/analysis_service_core/src/effort_model.py
+++ b/analysis_service_core/src/effort_model.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import List, TypeAlias, TypedDict
+from typing import List, Optional, TypeAlias, TypedDict
 from uuid import UUID
 
 from analysis_service_core.src.filesystem import get_final_output_dir
@@ -60,7 +60,10 @@ class EffortModel(ABC):
         raise NotImplementedError
 
     def _forward_pass_from_igroup(
-        self, dataset_dir: Path, task_id: UUID, igroup: InputGroup
+        self,
+        dataset_dir: Path,
+        igroup: InputGroup,
+        output_dir: Path,
     ) -> ForwardPass:
         """Construct a ForwardPass object from an input group and output directory."""
         return {
@@ -68,14 +71,19 @@ class EffortModel(ABC):
             "output_group": self.ogroup_from_igroup(
                 dataset_dir,
                 igroup,
-                output_dir=get_final_output_dir(dataset_dir, task_id),
+                output_dir=output_dir,
             ),
             "effort": self.effort_from_igroup(igroup),
         }
 
-    def get_progress(self, dataset_dir: Path, task_id: UUID) -> float:
+    def get_progress(
+        self,
+        dataset_dir: Path,
+        task_id: UUID,
+        model_output_folder: Optional[Path] = None,
+    ) -> float:
         """Calculate the progress so far as a fraction of the total effort."""
-        output_dir = get_final_output_dir(dataset_dir, task_id)
+        output_dir = model_output_folder or get_final_output_dir(dataset_dir, task_id)
 
         if not output_dir.exists():
             return 0.0
@@ -89,17 +97,19 @@ class EffortModel(ABC):
             if all(
                 out_file.exists() and out_file.is_file()
                 for out_file in self._forward_pass_from_igroup(
-                    dataset_dir, task_id, igroup
+                    dataset_dir,
+                    igroup,
+                    output_dir,
                 )["output_group"]
             )
         ]
 
         effort_so_far = sum(
-            self._forward_pass_from_igroup(dataset_dir, task_id, igroup)["effort"]
+            self._forward_pass_from_igroup(dataset_dir, igroup, output_dir)["effort"]
             for igroup in processed_igroups
         )
         total_effort = sum(
-            self._forward_pass_from_igroup(dataset_dir, task_id, igroup)["effort"]
+            self._forward_pass_from_igroup(dataset_dir, igroup, output_dir)["effort"]
             for igroup in igroups
         )
 

--- a/analysis_service_core/src/model.py
+++ b/analysis_service_core/src/model.py
@@ -107,7 +107,9 @@ class ModelPlugin(ABC):
 
         progress: float
         try:
-            progress = self._effort_model.get_progress(dataset_dir, task_id)
+            progress = self._effort_model.get_progress(
+                dataset_dir, task_id, self._model_output_folder
+            )
         except Exception:
             logger.exception("Problem calculating progress")
 


### PR DESCRIPTION
at present the model output folder is not really used inside model plugins (per atol's request)... However, if this changes in the future, where we want to use an "intermediary output folder" we will also need to make use of it to calculate progress

## Description of Issue

<Description of what is being addressed>

## Description of Solution

<Description of how the problems have been solved>

## Review
- [ ] Commits are atomic
- [ ] Checks are passing
- [ ] Code is sufficiently tested (sufficiently meaning, sometimes a lot, sometimes no need for tests at all)
