### PR TITLE
feat(model): pass in input groups in output group-related functions

### DIFF
--- a/analysis_service_core/src/effort_model.py
+++ b/analysis_service_core/src/effort_model.py
@@ -59,7 +59,11 @@ class EffortModel(ABC):
 
     @abstractmethod
     def ogroup_from_pogroup(
-        self, dataset_dir: Path, output_dir: Path, pogroup: PassOutputGroup
+        self,
+        dataset_dir: Path,
+        output_dir: Path,
+        pogroup: PassOutputGroup,
+        igroup: InputGroup,
     ) -> OutputGroup:
         """Return the final output group derived from a pass output group."""
         raise NotImplementedError
@@ -76,7 +80,10 @@ class EffortModel(ABC):
         return sorted([sorted(igroup) for igroup in self.find_igroups(dataset_dir)])
 
     def effort_ogroup_from_pogroup(
-        self, pogroup: PassOutputGroup, ogroup: OutputGroup
+        self,
+        pogroup: PassOutputGroup,
+        ogroup: OutputGroup,
+        igroup: InputGroup,
     ) -> float:
         """Return the effort of post-processing a pass output group. Defaults to 0."""
         return 0.0
@@ -116,6 +123,7 @@ class EffortModel(ABC):
             + self.effort_ogroup_from_pogroup(
                 fp["pass_output_group"],
                 [f for f in fp["output_group"] if f.exists() and f.is_file()],
+                igroup,
             )
             for igroup, fp in forward_passes
             if any(f.exists() and f.is_file() for f in fp["pass_output_group"])
@@ -147,10 +155,10 @@ class EffortModel(ABC):
     ) -> ForwardPass:
         """Construct a ForwardPass object from an input group and output directory."""
         pogroup = self.pogroup_from_igroup(dataset_dir, output_dir, igroup)
-        ogroup = self.ogroup_from_pogroup(dataset_dir, output_dir, pogroup)
+        ogroup = self.ogroup_from_pogroup(dataset_dir, output_dir, pogroup, igroup)
         effort = self.effort_pogroup_from_igroup(
             igroup, pogroup
-        ) + self.effort_ogroup_from_pogroup(pogroup, ogroup)
+        ) + self.effort_ogroup_from_pogroup(pogroup, ogroup, igroup)
 
         return {
             "input_group": igroup,

--- a/analysis_service_core/tests/models/word_count_effort_model.py
+++ b/analysis_service_core/tests/models/word_count_effort_model.py
@@ -28,12 +28,19 @@ class WordCountEffortModel(EffortModel):
         return pogroup
 
     def ogroup_from_pogroup(
-        self, dataset_dir: Path, output_dir: Path, pogroup: PassOutputGroup
+        self,
+        dataset_dir: Path,
+        output_dir: Path,
+        pogroup: PassOutputGroup,
+        igroup: InputGroup,
     ) -> OutputGroup:
         return [f for f in pogroup if f.name != "date.txt"]
 
     def effort_ogroup_from_pogroup(
-        self, pogroup: PassOutputGroup, ogroup: OutputGroup
+        self,
+        pogroup: PassOutputGroup,
+        ogroup: OutputGroup,
+        igroup: InputGroup,
     ) -> float:
         return 0.5 * len(ogroup)
 


### PR DESCRIPTION
this sometimes is necessary if the link between input and pass output is weak that not having the input group would make the app logic far too complex

## Description of Issue

<Description of what is being addressed>

## Description of Solution

<Description of how the problems have been solved>

## Review
- [ ] Commits are atomic
- [ ] Checks are passing
- [ ] Code is sufficiently tested (sufficiently meaning, sometimes a lot, sometimes no need for tests at all)
