### PR TITLE
ci: add code coverage

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -60,6 +60,8 @@ jobs:
         else
           echo "No integration tests found, skipping."
         fi
+    - name: Run code coverage
+      run: tox -e coverage -- --randomly-seed=$RANDOM
 
   e2e:
     name: E2E Tests

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ dist/
 .tox
 .mypy_cache
 .pytest_cache
+.coverage

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,20 @@ passenv =
     ECHOLALIA_DIR
     DATASETS_DIR
 
+[testenv:coverage]
+description = run tests with code coverage (fails under 25%)
+deps =
+    pytest
+    pytest-randomly
+    pytest-cov
+commands =
+    pytest --strict-markers -m "not e2e" --cov=analysis_service_core --cov-fail-under=25 {posargs}
+passenv =
+    REDIS_HOST
+    REDIS_PORT
+    ECHOLALIA_DIR
+    DATASETS_DIR
+
 [testenv:e2e]
 description = run end-to-end tests (requires Docker)
 deps =


### PR DESCRIPTION
I'm not a huge believer in code coverage chasing, but this tool does tell me the coverage over the individual modules, which is very useful. It can be used to look at coverage for new work. I set the bar low, at 25%. The actual percentage at present is just over 80% (pretty good I think)

## Review
- [ ] Commits are atomic
- [ ] Checks are passing
- [ ] Code is sufficiently tested (sufficiently meaning, sometimes a lot, sometimes no need for tests at all)
