### PR TITLE
revert: "fix(e2e-tests): run e2e tests as user, not as root"

### DIFF
--- a/analysis_service_core/testing/mixins/model_e2e_test_base.py
+++ b/analysis_service_core/testing/mixins/model_e2e_test_base.py
@@ -1,6 +1,5 @@
 """Base class for E2E model tests using Docker containers and Redis."""
 
-import os
 import shutil
 import threading
 import time
@@ -203,7 +202,6 @@ class ModelE2ETestBase:
             logger.info("Starting container and enqueuing task")
             container = (
                 DockerContainer(str(image))
-                .with_kwargs(user=f"{os.getuid()}:{os.getgid()}")
                 .with_network(network)
                 .with_envs(**env)
                 .with_volume_mapping(str(datasets_tmp), "/app/datasets", "rw")


### PR DESCRIPTION
Initially I discovered if you're running as root for the e2e test suite, test cleanup fails because pytest attempts to clean up after changes committed by the Docker daemon, and this gives permission denied problems—this happens if a test fails.

But then I changed it. Now there's another problem, I can't write to paths inside the container owned by a different user (see the Dockerfile chown that was recently added).

Now reverting this change... Honestly no big deal. Files are written to /tmp, and either (1) cleaned up on reboot or (2) run by ephemeral job runners that clean after themselves.

## Review
- [ ] Commits are atomic
- [ ] Checks are passing
- [ ] Code is sufficiently tested (sufficiently meaning, sometimes a lot, sometimes no need for tests at all)
